### PR TITLE
WhisperNode - cleanup RPC / API / gRPC / seed nodes

### DIFF
--- a/akash/chain.json
+++ b/akash/chain.json
@@ -146,6 +146,11 @@
         "id": "9aa4c9097c818871e45aaca4118a9fe5e86c60e2",
         "address": "seed-akash-01.stakeflow.io:1506",
         "provider": "Stakeflow"
+      },
+      {
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
+        "address": "seeds.whispernode.com:12856",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -238,6 +243,10 @@
       {
         "address": "https://akash-rpc.validatornode.com",
         "provider": "ValidatorNode"
+      },
+      {
+        "address": "https://rpc-akash.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "rest": [
@@ -300,6 +309,10 @@
       {
         "address": "https://akash-api.validatornode.com",
         "provider": "ValidatorNode"
+      },
+      {
+        "address": "https://lcd-akash.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "grpc": [

--- a/archway/chain.json
+++ b/archway/chain.json
@@ -151,9 +151,9 @@
         "provider": "AM Solutions"
       },
       {
-        "id": "d2362ebcdd562500ac8c4cfa2214a89ad811033c",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:11556",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
@@ -271,8 +271,8 @@
         "provider": "AM Solutions"
       },
       {
-        "address": "https://rpc-archway.whispernode.com",
-        "provider": "WhisperNode🤐"
+        "address": "https://rpc-archway.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://archway-rpc.w3coins.io",
@@ -390,7 +390,7 @@
       },
       {
         "address": "https://lcd-archway.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://archway-api.lavenderfive.com:443",

--- a/assetmantle/chain.json
+++ b/assetmantle/chain.json
@@ -69,14 +69,9 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "990557213003ab234cc03307d02688c30357fed6",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:14656",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:14656",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "df949a46ae6529ae1e09b034b49716468d5cc7e9",
@@ -167,11 +162,7 @@
       },
       {
         "address": "https://rpc-assetmantle.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rpc-assetmantle.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc.mantle.paranorm.pro:443",
@@ -213,11 +204,7 @@
       },
       {
         "address": "https://lcd-assetmantle.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rest-assetmantle.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api.mantle.paranorm.pro:443",

--- a/aura/chain.json
+++ b/aura/chain.json
@@ -113,11 +113,6 @@
         "provider": "kjnodes"
       },
       {
-        "id": "dc92560346a63ac23e117a8b16207c6adbb57f5e",
-        "address": "seeds.whispernode.com:21756",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:21756",
         "provider": "Lavender.Five Nodes 🐝"
@@ -208,10 +203,6 @@
         "provider": "🔥STAVR🔥"
       },
       {
-        "address": "https://rpc-aura.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "address": "https://aura-rpc.ramuchi.tech",
         "provider": "ramuchi.tech"
       },
@@ -284,10 +275,6 @@
       {
         "address": "https://api.aura.nodestake.top",
         "provider": "NodeStake"
-      },
-      {
-        "address": "https://lcd-aura.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://aura-api.ramuchi.tech",

--- a/axelar/chain.json
+++ b/axelar/chain.json
@@ -99,19 +99,14 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "1e5c0b8f4431b0881edbd04537f4351bd7f19afc",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:15156",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "3470414cd299d15911e9bb28557f6bffb8e514c6",
         "address": "seed-axelar-01.stakeflow.io:1606",
         "provider": "Stakeflow"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:15156",
-        "provider": "carbonZERO🌲"
       }
     ],
     "persistent_peers": [
@@ -198,7 +193,7 @@
       },
       {
         "address": "https://rpc-axelar.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://axelar-rpc.quantnode.tech/",
@@ -223,10 +218,6 @@
       {
         "address": "https://axelar-rpc.staketab.org:443",
         "provider": "Staketab"
-      },
-      {
-        "address": "https://rpc-axelar.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       },
       {
         "address": "https://axelar-rpc.w3coins.io",
@@ -280,7 +271,7 @@
       },
       {
         "address": "https://lcd-axelar.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://axelar-mainnet-lcd.autostake.com:443",
@@ -301,10 +292,6 @@
       {
         "address": "https://axelar-rest.staketab.org",
         "provider": "Staketab"
-      },
-      {
-        "address": "https://rest-axelar.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       },
       {
         "address": "https://axelar-api.w3coins.io",
@@ -349,12 +336,12 @@
         "provider": "Stakeflow"
       },
       {
-        "address": "grpc-axelar.carbonzero.zone:443",
-        "provider": "carbonZERO🌲"
-      },
-      {
         "address": "axelar-grpc.w3coins.io:15190",
         "provider": "w3coins"
+      },
+      {
+        "address": "grpc-axelar.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/cheqd/chain.json
+++ b/cheqd/chain.json
@@ -108,14 +108,9 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "d8676573a3718c05d3d0d07906f3604a9e3a034d",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:16156",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:16156",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -161,15 +156,11 @@
       },
       {
         "address": "https://rpc-cheqd.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://cheqd-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rpc-cheqd.carbonzero.zone:443",
-        "provider": "carbonZERO🌲"
       }
     ],
     "rest": [
@@ -195,11 +186,7 @@
       },
       {
         "address": "https://lcd-cheqd.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rest-cheqd.carbonzero.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       }
     ],
     "grpc": [
@@ -224,8 +211,8 @@
         "provider": "NodeStake"
       },
       {
-        "address": "grpc-cheqd.carbonzero.zone:443",
-        "provider": "carbonZERO🌲"
+        "address": "grpc-cheqd.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/chihuahua/chain.json
+++ b/chihuahua/chain.json
@@ -157,16 +157,6 @@
         "id": "e726816f42831689eab9378d5d577f1d06d25716",
         "address": "chihuahua-seed-us.allnodes.me:26656",
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
-      },
-      {
-        "id": "3c5b1a13f810507b9ef1240372b3cbc9bd90da26",
-        "address": "seeds.whispernode.com:12956",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:12956",
-        "provider": "carbonZERO🌲"
       }
     ],
     "persistent_peers": [
@@ -221,10 +211,6 @@
         "provider": "PUPMØS"
       },
       {
-        "address": "https://rpc-chihuahua.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "address": "https://rpc-chihuahua.cosmos-spaces.cloud",
         "provider": "Cosmos Spaces"
       },
@@ -273,10 +259,6 @@
       {
         "address": "https://api-chihuahua.pupmos.network",
         "provider": "PUPMØS"
-      },
-      {
-        "address": "https://lcd-chihuahua.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://rest-chihuahua.goldenratiostaking.net",

--- a/comdex/chain.json
+++ b/comdex/chain.json
@@ -113,14 +113,9 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "243d93ff2f663860f118fa32e2122fbba7f00a92",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:13156",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:13156",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "88ba33fbdf0279efaf27cff629f3cf72814d4069",
@@ -182,11 +177,7 @@
       },
       {
         "address": "https://rpc-comdex.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rpc-comdex.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://comdex-mainnet-rpc.autostake.com:443",
@@ -240,11 +231,7 @@
       },
       {
         "address": "https://lcd-comdex.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rest-comdex.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://comdex-api.w3coins.io",

--- a/composable/chain.json
+++ b/composable/chain.json
@@ -170,9 +170,9 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "d2362ebcdd562500ac8c4cfa2214a89ad811033c",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:22256",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -230,7 +230,7 @@
       },
       {
         "address": "https://rpc-composable.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://composable-rpc.stake-town.com",
@@ -272,7 +272,7 @@
       },
       {
         "address": "https://lcd-composable.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://composable-api.stake-town.com",

--- a/cosmoshub/chain.json
+++ b/cosmoshub/chain.json
@@ -203,10 +203,10 @@
         "provider": "Golden Ratio Staking"
       },
       {
-        "id": "7aa410eb8f699c366b1f1e2904ba6b0d1cac379b",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:14956",
-        "provider": "WhisperNode🤐"
-      },
+        "provider": "WhisperNode 🤐"
+      }
       {
         "id": "e1b058e5cfa2b836ddaa496b10911da62dcf182e",
         "address": "cosmoshub-seed-de.allnodes.me:26656",
@@ -290,7 +290,7 @@
       },
       {
         "address": "https://rpc-cosmoshub.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://cosmoshub-rpc.lavenderfive.com:443",
@@ -488,7 +488,7 @@
       },
       {
         "address": "https://lcd-cosmoshub.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://cosmos-lcd.easy2stake.com",
@@ -606,7 +606,7 @@
       },
       {
         "address": "grpc-cosmoshub.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "cosmos-grpc.w3coins.io:14990",

--- a/desmos/chain.json
+++ b/desmos/chain.json
@@ -136,11 +136,6 @@
         "provider": "Panthea EU"
       },
       {
-        "id": "6580d5123923ec1426c67658d2ae1e68cfd6a62f",
-        "address": "seeds.whispernode.com:16256",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "id": "b7c72e371caca2e5287c0d9a68bfcdabc93fc664",
         "address": "seed-desmos.ibs.team:16658",
         "provider": "Inter Blockchain Services"
@@ -181,10 +176,6 @@
       {
         "address": "http://desmos.statesync.nodersteam.com:12657",
         "provider": "[NODERS]TEAM"
-      },
-      {
-        "address": "https://rpc-desmos.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://rpc-desmos.explorer.co.id",

--- a/empowerchain/chain.json
+++ b/empowerchain/chain.json
@@ -73,9 +73,9 @@
         "address": "seed.empowerchain.io:26656"
       },
       {
-        "id": "d2362ebcdd562500ac8c4cfa2214a89ad811033c",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:17456",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "9aa8a73ea9364aa3cf7806d4dd25b6aed88d8152",
@@ -122,7 +122,7 @@
       },
       {
         "address": "https://rpc-empower.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc-empowerchain.mzonder.com:443",
@@ -168,7 +168,7 @@
       },
       {
         "address": "https://lcd-empower.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api-empowerchain.mzonder.com:443",

--- a/evmos/chain.json
+++ b/evmos/chain.json
@@ -222,16 +222,6 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "e4f7c3181d0028209c664bfd4c259f2c4d947491",
-        "address": "seeds.whispernode.com:13456",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:13456",
-        "provider": "carbonZERO🌲"
-      },
-      {
         "id": "ac009a9564d3471852795b5d703095a1d4b6a3e1",
         "address": "seed-evmos-01.stakeflow.io:1707",
         "provider": "Stakeflow"
@@ -285,10 +275,6 @@
       {
         "address": "https://rpc-evmos.ecostake.com",
         "provider": "ecostake"
-      },
-      {
-        "address": "https://rpc-evmos.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://evmos-rpc.lavenderfive.com:443",
@@ -404,10 +390,6 @@
       }
     ],
     "rest": [
-      {
-        "address": "https://lcd-evmos.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
       {
         "address": "https://rest.bd.evmos.org:1317",
         "provider": "Blockdaemon"

--- a/gitopia/chain.json
+++ b/gitopia/chain.json
@@ -164,9 +164,9 @@
         "provider": "autostake"
       },
       {
-        "id": "d2362ebcdd562500ac8c4cfa2214a89ad811033c",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:11356",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "187425bc3739daaef8cb1d7cf47d655117396dbe",
@@ -339,7 +339,7 @@
       },
       {
         "address": "https://rpc-gitopia.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc.gitopia.hexnodes.co",
@@ -497,7 +497,7 @@
       },
       {
         "address": "https://lcd-gitopia.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://lcd.gitopia.hexnodes.co",
@@ -636,10 +636,6 @@
       {
         "address": "gitopia-grpc.genznodes.dev:33090",
         "provider": "genznodes"
-      },
-      {
-        "address": "grpc-gitopia.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://grpc.gitopia.hexnodes.co:16090",

--- a/injective/chain.json
+++ b/injective/chain.json
@@ -151,9 +151,9 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "62ae24dfc6841ff1ab513522255c94914861df7c",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:14356",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "858c86e2590f82934b8483ed184afd88416a7b31",
@@ -240,7 +240,7 @@
       },
       {
         "address": "https://rpc-injective.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc-injective.architectnodes.com",
@@ -298,7 +298,7 @@
       },
       {
         "address": "https://lcd-injective.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rest-injective.architectnodes.com",
@@ -373,6 +373,10 @@
       {
         "address": "injective-grpc.tienthuattoan.ventures:9900",
         "provider": "TienThuatToan"
+      },
+      {
+        "address": "grpc-injective.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/jackal/chain.json
+++ b/jackal/chain.json
@@ -139,14 +139,9 @@
         "provider": "kjnodes"
       },
       {
-        "id": "f6c5d2bf222699a35968e5f262baacd6c34e261c",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:17556",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:17556",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -241,15 +236,11 @@
       },
       {
         "address": "https://rpc-jackal.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://jackal-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rpc-jackal.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       },
       {
         "address": "http://jackal.rpc.nodersteam.com:31657",
@@ -323,7 +314,7 @@
       },
       {
         "address": "https://lcd-jackal.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://jackal.api.kjnodes.com",
@@ -332,10 +323,6 @@
       {
         "address": "https://jackal.api.silknodes.io",
         "provider": "Silk Nodes"
-      },
-      {
-        "address": "https://rest-jackal.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       }
     ],
     "grpc": [

--- a/juno/chain.json
+++ b/juno/chain.json
@@ -162,9 +162,9 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "47d942718533d36823e16b9502c035ca9f318ef4",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:12656",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "509f6dbae3133a9df177edea051b31e1210b117e",
@@ -213,7 +213,7 @@
     "rpc": [
       {
         "address": "https://rpc-juno.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc-juno.goldenratiostaking.net",
@@ -436,6 +436,10 @@
       {
         "address": "https://api-juno.mainnet.validatrium.club",
         "provider": "Validatrium"
+      },
+      {
+        "address": "https://lcd-juno.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "grpc": [

--- a/kujira/chain.json
+++ b/kujira/chain.json
@@ -156,7 +156,7 @@
       {
         "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:11856",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "654ba97f74254965a80c0fac0f277f6f6e5506b6",
@@ -181,7 +181,7 @@
     "rpc": [
       {
         "address": "https://rpc-kujira.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc.kaiyo.kujira.setten.io",
@@ -271,7 +271,7 @@
     "rest": [
       {
         "address": "https://lcd-kujira.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rest-kujira.goldenratiostaking.net",
@@ -378,6 +378,10 @@
       {
         "address": "kujira-grpc.publicnode.com:443",
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
+      },
+      {
+        "address": "grpc-kujira.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/mars/chain.json
+++ b/mars/chain.json
@@ -111,16 +111,6 @@
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "mars.rpc.kjnodes.com:14559",
         "provider": "kjnodes"
-      },
-      {
-        "id": "c4168cce14ec32e067cf153a08a1b85be881e25a",
-        "address": "seeds.whispernode.com:18556",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:18556",
-        "provider": "carbonZERO🌲"
       }
     ],
     "persistent_peers": [
@@ -154,20 +144,12 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://rpc-mars.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "address": "https://rpc.expedition-mars.com",
         "provider": "Expedition Mars"
       },
       {
         "address": "https://mars-rpc.genznodes.dev:443",
         "provider": "genznodes"
-      },
-      {
-        "address": "https://rpc-mars.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       },
       {
         "address": "https://mars-rpc.stakeandrelax.net",
@@ -204,20 +186,12 @@
         "provider": "Polkachu"
       },
       {
-        "address": "https://lcd-mars.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "address": "https://lcd.expedition-mars.com:443",
         "provider": "Expedition Mars"
       },
       {
         "address": "https://mars-api.genznodes.dev:443",
         "provider": "genznodes"
-      },
-      {
-        "address": "https://rest-mars.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       },
       {
         "address": "https://mars-api.stakeandrelax.net",

--- a/migaloo/chain.json
+++ b/migaloo/chain.json
@@ -153,16 +153,6 @@
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
         "address": "migaloo.rpc.kjnodes.com:14959",
         "provider": "kjnodes"
-      },
-      {
-        "id": "1b6a3dd166b8814f3064444206c2194a92dea62d",
-        "address": "seeds.whispernode.com:20756",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:20756",
-        "provider": "carbonZERO🌲"
       }
     ],
     "persistent_peers": [
@@ -188,16 +178,8 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "address": "https://rpc-whitewhale.carbonzero.zone:443",
-        "provider": "carbonZERO🌲"
-      },
-      {
         "address": "https://rpc-migaloo.cosmos-spaces.cloud",
         "provider": "Cosmos Spaces"
-      },
-      {
-        "address": "https://rpc-whitewhale.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://migaloo-rpc.kleomedes.network:443",
@@ -228,14 +210,6 @@
       {
         "address": "https://whitewhale-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://rest-whitewhale.carbonzero.zone:443",
-        "provider": "carbonZERO🌲"
-      },
-      {
-        "address": "https://lcd-whitewhale.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://api-migaloo.cosmos-spaces.cloud",

--- a/neutron/chain.json
+++ b/neutron/chain.json
@@ -102,9 +102,9 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "f4422e68f9a678838522d75fa8221985c723294d",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:19156",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "e1b058e5cfa2b836ddaa496b10911da62dcf182e",
@@ -141,7 +141,7 @@
       },
       {
         "address": "https://rpc-neutron.whispernode.com",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc-neutron.cosmos-spaces.cloud",
@@ -183,7 +183,7 @@
       },
       {
         "address": "https://lcd-neutron.whispernode.com",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api-neutron.cosmos-spaces.cloud",
@@ -221,7 +221,7 @@
       },
       {
         "address": "grpc-neutron.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "grpc-neutron.cosmos-spaces.cloud:3090",

--- a/nomic/chain.json
+++ b/nomic/chain.json
@@ -71,14 +71,9 @@
         "provider": "Golden Ratio Staking"
       },
       {
-        "id": "10beadbcd4bc5fef8a1f5f57353bdb8646f7a554",
-        "address": "seeds.whispernode.com:26656",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:12756",
-        "provider": "carbonZERO🌲"
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
+        "address": "seeds.whispernode.com:12756",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": []
@@ -103,11 +98,7 @@
       },
       {
         "address": "https://rpc-nomic.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rpc-nomic.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       }
     ],
     "rest": [

--- a/osmosis/chain.json
+++ b/osmosis/chain.json
@@ -369,9 +369,9 @@
         "provider": "FreshSTAKING"
       },
       {
-        "id": "bd7064a50f5843e2c84c71c4dc18ac07424bdcc1",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:12556",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "400f3d9e30b69e78a7fb891f60d76fa3c73f0ecc",
@@ -629,7 +629,7 @@
       },
       {
         "address": "https://lcd-osmosis.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api-osmosis.mms.team",
@@ -720,6 +720,10 @@
       {
         "address": "osmosis-mainnet.grpc.l0vd.com:80",
         "provider": "L0vd.com ❤️"
+      },
+      {
+        "address": "grpc-osmosis.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
       }
     ]
   },

--- a/passage/chain.json
+++ b/passage/chain.json
@@ -112,9 +112,9 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "2534bb8af72ab14e001a9f48b7cf9626221c6be5",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:15656",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "df949a46ae6529ae1e09b034b49716468d5cc7e9",
@@ -187,7 +187,7 @@
       },
       {
         "address": "https://rpc-passage.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://passage-mainnet-rpc.autostake.com:443",
@@ -249,7 +249,7 @@
       },
       {
         "address": "https://lcd-passage.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://passage-rest.stakerhouse.com",

--- a/quasar/chain.json
+++ b/quasar/chain.json
@@ -134,9 +134,9 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "d3c60cb339736ab2d504904492fe4e7d9efe5d42",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:18256",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -163,7 +163,7 @@
       },
       {
         "address": "https://rpc-quasar.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://quasar-rpc.enigma-validator.com",
@@ -205,7 +205,7 @@
       },
       {
         "address": "https://lcd-quasar.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api-quasar.cosmos-spaces.cloud",

--- a/secretnetwork/chain.json
+++ b/secretnetwork/chain.json
@@ -190,9 +190,9 @@
         "provider": "Lavender.Five Nodes 🐝"
       },
       {
-        "id": "d6a6edd7d3d04b59955e135e2d27b7dcc285ead7",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:17156",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "5b0d6ef879fe1326045fa18d5bf767c5968704e6",
@@ -230,7 +230,7 @@
       },
       {
         "address": "https://rpc-secret.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://secret-rpc.bharvest.io",
@@ -256,7 +256,7 @@
       },
       {
         "address": "https://lcd-secret.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "http://secretnetwork-mainnet-lcd.autostake.com:1317",

--- a/sei/chain.json
+++ b/sei/chain.json
@@ -124,7 +124,7 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "7cbcea0b3041960d1d7b8a6a2eccce0e1f7add50",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:11956",
         "provider": "WhisperNode 🤐"
       },

--- a/sentinel/chain.json
+++ b/sentinel/chain.json
@@ -107,10 +107,10 @@
         "provider": "BadgerBite"
       },
       {
-        "id": "1a409560619766355f818ef2e42c935453782635",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:17256",
-        "provider": "WhisperNode🤐"
-      }
+        "provider": "WhisperNode 🤐"
+      },
     ],
     "persistent_peers": [
       {
@@ -268,7 +268,7 @@
       },
       {
         "address": "https://rpc-sentinel.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://rpc.sentinel.chaintools.tech/",
@@ -310,7 +310,7 @@
       },
       {
         "address": "https://lcd-sentinel.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://api.sentinel.quokkastake.io",

--- a/stargaze/chain.json
+++ b/stargaze/chain.json
@@ -120,9 +120,9 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "604f4baaa30cd3f50d080bf45806d222c7fadc94",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:13756",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "96e0040d44a2f0b59d2a07e128369363d8535b67",
@@ -197,7 +197,7 @@
       },
       {
         "address": "https://rpc-stargaze.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stargaze-mainnet-rpc.autostake.com:443",
@@ -271,7 +271,7 @@
       },
       {
         "address": "https://lcd-stargaze.whispernode.com:443",
-        "provider": "WhisperNode🤐"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stargaze-api.ramuchi.tech",

--- a/stratos/chain.json
+++ b/stratos/chain.json
@@ -55,6 +55,11 @@
         "id": "ce225e67f7a383b50c91aeb902a86dd3ecb70d65",
         "address": "34.84.212.13:26656",
         "provider": "thestratos.org"
+      },
+      {
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
+        "address": "seeds.whispernode.com:21856",
+        "provider": "WhisperNode 🤐"
       }
     ],
     "persistent_peers": [
@@ -78,7 +83,11 @@
       {
         "address": "http://stratos.rpc.nodersteam.com:26657/",
         "provider": "[NODERS]TEAM"
-      }
+      },
+      {
+        "address": "https://rpc-stratos.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
+      }     
     ],
     "rest": [
       {
@@ -92,7 +101,11 @@
       {
         "address": "http://stratos.api.nodersteam.com:1317",
         "provider": "[NODERS]TEAM"
-      }
+      },
+      {
+        "address": "https://lcd-stratos.whispernode.com:443",
+        "provider": "WhisperNode 🤐"
+      } 
     ],
     "grpc": [
       {

--- a/stride/chain.json
+++ b/stride/chain.json
@@ -354,14 +354,9 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "95d0377592a657d4c0816d9845e11d659db75d5b",
+        "id": "c28827cb96c14c905b127b92065a3fb4cd77d7f6",
         "address": "seeds.whispernode.com:12256",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:12256",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "id": "ced7684f4d60399986cdbc1465ac00a420a14202",
@@ -459,11 +454,7 @@
       },
       {
         "address": "https://rpc-stride.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rpc-stride.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stride-mainnet-rpc.autostake.com:443",
@@ -553,11 +544,7 @@
       },
       {
         "address": "https://lcd-stride.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rest-stride.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
+        "provider": "WhisperNode 🤐"
       },
       {
         "address": "https://stride-api.stakeandrelax.net",

--- a/teritori/chain.json
+++ b/teritori/chain.json
@@ -99,16 +99,6 @@
         "provider": "AutoStake 🛡️ Slash Protected"
       },
       {
-        "id": "8f75bd347c90fbaa2c96eb187a413bb3751b3a7e",
-        "address": "seeds.whispernode.com:15956",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "id": "27b6d74c8408e033e2e5a9e966a0d15782e33596",
-        "address": "seeds.nethernode.xyz:15956",
-        "provider": "carbonZERO🌲"
-      },
-      {
         "id": "1ef268d56b79edbd0c32815f4bf9c362a0617ed4",
         "address": "seed-teritori.ibs.team:16659",
         "provider": "Inter Blockchain Services"
@@ -206,14 +196,6 @@
         "provider": "PUPMØS"
       },
       {
-        "address": "https://rpc-teritori.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rpc-teritori.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
-      },
-      {
         "address": "https://teritori-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -278,14 +260,6 @@
       {
         "address": "https://api-teritori.pupmos.network",
         "provider": "PUPMØS"
-      },
-      {
-        "address": "https://lcd-teritori.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
-        "address": "https://rest-teritori.carbonZERO.zone:443",
-        "provider": "carbonZERO🌲"
       },
       {
         "address": "https://teritori-mainnet-lcd.autostake.com:443",

--- a/terra2/chain.json
+++ b/terra2/chain.json
@@ -229,11 +229,6 @@
         "provider": "Allnodes.com ⚡️ Nodes & Staking"
       },
       {
-        "id": "1e094db9c147a0fd5e9793365d66736c80bfef46",
-        "address": "seeds.whispernode.com:11756",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "id": "a8d12536bdcc210ac35a9f092f3295360b97830d",
         "address": "seed-terra-01.stakeflow.io:33007",
         "provider": "Stakeflow"
@@ -288,10 +283,6 @@
         "provider": "stakely"
       },
       {
-        "address": "https://rpc-terra2.whispernode.com:443",
-        "provider": "WhisperNode🤐"
-      },
-      {
         "address": "https://terra-mainnet-rpc.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
       },
@@ -324,10 +315,6 @@
       {
         "address": "https://terra-mainnet-lcd.autostake.com:443",
         "provider": "AutoStake 🛡️ Slash Protected"
-      },
-      {
-        "address": "https://lcd-terra2.whispernode.com:443",
-        "provider": "WhisperNode🤐"
       },
       {
         "address": "https://phoenix-lcd.terra.dev:443",


### PR DESCRIPTION
updated all chains we actively validate with current public endpoint details (new uniform peer ID for seed nodes).

removed endpoints from chains we no longer validate.
